### PR TITLE
Add ability to use SES module only for outgoing emails through a boolean flag value

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ data "aws_route53_zone" "SES_domain" {
 
 ## Inputs
 
-| Name | Description | Type | Default | Required | Notes |
-|------|-------------|:----:|:-----:|:-----:|:-----:|
-| dmarc_rua | Email address for capturing DMARC aggregate reports. | string | - | yes | |
-| domain_name | The domain name to configure SES. | string | - | yes | |
-| enable_verification | Control whether or not to verify SES DNS records. | string | `true` | no | |
-| from_addresses | List of email addresses to catch bounces and rejections | list | - | yes | |
-| mail_from_domain | Subdomain (of the route53 zone) which is to be used as MAIL FROM address | string | - | yes | |
-| receive_s3_bucket | Name of the S3 bucket to store received emails. | string | - | *yes | *value can be empty string if `enable_incoming_email` is set to false|
-| receive_s3_prefix | The key prefix of the S3 bucket to store received emails. | string | - | *yes | *value can be empty string if `enable_incoming_email` is set to false|
-| route53_zone_id | Route53 host zone ID to enable SES. | string | - | yes |
-| ses_rule_set | Name of the SES rule set to associate rules with. | string | - | *yes | *value can be empty string if `enable_incoming_email` is set to false|
-| enable_incoming_email | Control whether or not to enable incoming emails through an MX record | string | `true` | no | |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| dmarc\_rua | Email address for capturing DMARC aggregate reports. | string | n/a | yes |
+| domain\_name | The domain name to configure SES. | string | n/a | yes |
+| enable\_incoming\_email | Control whether or not to handle incoming emails | string | `"true"` | no |
+| enable\_verification | Control whether or not to verify SES DNS records. | string | `"true"` | no |
+| from\_addresses | List of email addresses to catch bounces and rejections | list | n/a | yes |
+| mail\_from\_domain | Subdomain (of the route53 zone) which is to be used as MAIL FROM address | string | n/a | yes |
+| receive\_s3\_bucket | Name of the S3 bucket to store received emails. | string | n/a | yes |
+| receive\_s3\_prefix | The key prefix of the S3 bucket to store received emails. | string | n/a | yes |
+| route53\_zone\_id | Route53 host zone ID to enable SES. | string | n/a | yes |
+| ses\_rule\_set | Name of the SES rule set to associate rules with. | string | n/a | yes |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -37,5 +37,6 @@ module "ses_domain" {
 | receive_s3_prefix | The key prefix of the S3 bucket to store received emails. | string | - | yes |
 | route53_zone_id | Route53 host zone ID to enable SES. | string | - | yes |
 | ses_rule_set | Name of the SES rule set to associate rules with. | string | - | yes |
+| enable_incoming_email | Control whether or not to enable incoming emails through an MX record | string | `true` | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ module "ses_domain" {
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| dmarc_rua | Email address for capturing DMARC aggregate reports. | string | - | yes |
-| domain_name | The domain name to configure SES. | string | - | yes |
-| enable_verification | Control whether or not to verify SES DNS records. | string | `true` | no |
-| from_addresses | List of email addresses to catch bounces and rejections | list | - | yes |
-| mail_from_domain | Subdomain (of the route53 zone) which is to be used as MAIL FROM address | string | - | yes |
-| receive_s3_bucket | Name of the S3 bucket to store received emails. | string | - | yes |
-| receive_s3_prefix | The key prefix of the S3 bucket to store received emails. | string | - | yes |
+| Name | Description | Type | Default | Required | Notes |
+|------|-------------|:----:|:-----:|:-----:|:-----:|
+| dmarc_rua | Email address for capturing DMARC aggregate reports. | string | - | yes | |
+| domain_name | The domain name to configure SES. | string | - | yes | |
+| enable_verification | Control whether or not to verify SES DNS records. | string | `true` | no | |
+| from_addresses | List of email addresses to catch bounces and rejections | list | - | yes | |
+| mail_from_domain | Subdomain (of the route53 zone) which is to be used as MAIL FROM address | string | - | yes | |
+| receive_s3_bucket | Name of the S3 bucket to store received emails. | string | - | *yes | *value can be empty string if `enable_incoming_email` is set to false|
+| receive_s3_prefix | The key prefix of the S3 bucket to store received emails. | string | - | *yes | *value can be empty string if `enable_incoming_email` is set to false|
 | route53_zone_id | Route53 host zone ID to enable SES. | string | - | yes |
-| ses_rule_set | Name of the SES rule set to associate rules with. | string | - | yes |
-| enable_incoming_email | Control whether or not to enable incoming emails through an MX record | string | `true` | no |
+| ses_rule_set | Name of the SES rule set to associate rules with. | string | - | *yes | *value can be empty string if `enable_incoming_email` is set to false|
+| enable_incoming_email | Control whether or not to enable incoming emails through an MX record | string | `true` | no | |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ resource "aws_route53_record" "mx_send_mail_from" {
 
 # Receiving MX Record
 resource "aws_route53_record" "mx_receive" {
+  count = "${var.enable_incoming_email ? 1 : 0}"
   zone_id = "${var.route53_zone_id}"
   name    = "${var.domain_name}"
   type    = "MX"

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "aws_route53_record" "mx_send_mail_from" {
 
 # Receiving MX Record
 resource "aws_route53_record" "mx_receive" {
-  count = "${var.enable_incoming_email ? 1 : 0}"
+  count   = "${var.enable_incoming_email ? 1 : 0}"
   zone_id = "${var.route53_zone_id}"
   name    = "${var.domain_name}"
   type    = "MX"
@@ -138,6 +138,7 @@ resource "aws_route53_record" "txt_dmarc" {
 
 resource "aws_ses_receipt_rule" "main" {
   name          = "${format("%s-s3-rule", local.dash_domain)}"
+  count         = "${var.enable_incoming_email ? 1 : 0}"
   rule_set_name = "${var.ses_rule_set}"
   recipients    = ["${var.from_addresses}"]
   enabled       = true

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,9 @@ variable "ses_rule_set" {
   description = "Name of the SES rule set to associate rules with."
   type        = "string"
 }
+
+variable "enable_incoming_email" {
+  description = "Control whether or not to handle incoming emails"
+  type        = "string"
+  default     = true
+}


### PR DESCRIPTION
Make this module friendly for just outgoing email 
-------------------------------------------------
An example use case would be an organization using SES to handle outgoing emails but incoming emails are handled by fastmail or gmail. 

The new variable for this module`enable_incoming_email` now allows users to conditionally handle incoming email. By default incoming emails are handled by the module but it can be set to `false` which will skip creating incoming email MX dns record and will allow email to pass through to a provider like gmail or fastmail

Screenshot of fastmail inbox still receiving emails after SES is successfully configured for porchetta.io:
---------------------------------------
![image](https://user-images.githubusercontent.com/5003421/47729263-37f5cb00-dc36-11e8-8510-09cdf0e6edf8.png)
