### PR TITLE
Terraform 0.12 compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_route53_record" "txt_dmarc" {
 resource "aws_ses_receipt_rule" "main" {
   name          = "${format("%s-s3-rule", local.dash_domain)}"
   rule_set_name = "${var.ses_rule_set}"
-  recipients    = ["${var.from_addresses}"]
+  recipients    = "${var.from_addresses}"
   enabled       = true
   scan_enabled  = true
 


### PR DESCRIPTION
This PR makes this module compatible with Terraform 0.12, in a way that should be backwards compatible with Terraform 0.11. Brackets have not been required around list expressions for a while now, and Terraform 0.12 now interprets such things as nested lists, so this PR drops the brackets, which keeps backwards compatibility with TF 0.11.