### PR TITLE
added variable to enable/disable route53 spf record

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,6 +126,7 @@ resource "aws_route53_record" "spf_mail_from" {
 }
 
 resource "aws_route53_record" "spf_domain" {
+  count   = var.enable_spf_record ? 1 : 0
   zone_id = var.route53_zone_id
   name    = var.domain_name
   type    = "TXT"

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,12 @@ variable "ses_rule_set" {
 
 variable "enable_incoming_email" {
   description = "Control whether or not to handle incoming emails"
-  type        = "string"
+  type        = bool
+  default     = true
+}
+
+variable "enable_spf_record" {
+  description = "Control whether or not to create SPF record"
+  type        = bool
   default     = true
 }


### PR DESCRIPTION
Our domain already has a TXT record which contains multiple entries for domain verification, etc. It can´t be overwritten by the module.