### PR TITLE
Add option to disable SPF record creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ data "aws_route53_zone" "SES_domain" {
 | dmarc\_rua | Email address for capturing DMARC aggregate reports. | string | n/a | yes |
 | domain\_name | The domain name to configure SES. | string | n/a | yes |
 | enable\_incoming\_email | Control whether or not to handle incoming emails | string | `"true"` | no |
+| enable\_spf\_record | Control whether or not to set SPF records. | bool | `"true"` | no |
 | enable\_verification | Control whether or not to verify SES DNS records. | string | `"true"` | no |
 | from\_addresses | List of email addresses to catch bounces and rejections | list(string) | n/a | yes |
-| mail\_from\_domain | Subdomain (of the route53 zone) which is to be used as MAIL FROM address | string | n/a | yes |
+| mail\_from\_domain | Subdomain \(of the route53 zone\) which is to be used as MAIL FROM address | string | n/a | yes |
 | receive\_s3\_bucket | Name of the S3 bucket to store received emails. | string | n/a | yes |
 | receive\_s3\_prefix | The key prefix of the S3 bucket to store received emails. | string | n/a | yes |
 | route53\_zone\_id | Route53 host zone ID to enable SES. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,7 @@ resource "aws_ses_domain_mail_from" "main" {
 
 # SPF validaton record
 resource "aws_route53_record" "spf_mail_from" {
+  count   = var.enable_spf_record ? 1 : 0
   zone_id = var.route53_zone_id
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "TXT"
@@ -126,6 +127,7 @@ resource "aws_route53_record" "spf_mail_from" {
 }
 
 resource "aws_route53_record" "spf_domain" {
+  count   = var.enable_spf_record ? 1 : 0
   zone_id = var.route53_zone_id
   name    = var.domain_name
   type    = "TXT"

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,9 @@ variable "enable_incoming_email" {
   type        = "string"
   default     = true
 }
+
+variable "enable_spf_record" {
+  description = "Control whether or not to set SPF records."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "ses_rule_set" {
 
 variable "enable_incoming_email" {
   description = "Control whether or not to handle incoming emails"
-  type        = "string"
+  type        = bool
   default     = true
 }
 


### PR DESCRIPTION
I want to register not only SPF record but google site verification for the domain apex TXT record.
#13 enables specifying an arbitrary SPF record, but it overwrites existing TXT records (removes google site verification).

Option for accepting list of TXT records is possible way, but receiving irrelevant parameters is not smart way.
Such users I believe should be responsible to manage whole TXT records for their domains, so I took an idea to provide a way to disable TXT records in this module.