### PR TITLE
Configurable spf records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:e66fbea875bcb788b29b1b5f59142e8231961ec5
+  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:2f6321ed86ed79bfed23b04dd6dfdbe7bc943fdc
 
 jobs:
   terratest:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ data "aws_route53_zone" "SES_domain" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -69,12 +75,13 @@ data "aws_route53_zone" "SES_domain" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | dmarc\_rua | Email address for capturing DMARC aggregate reports. | `string` | n/a | yes |
 | domain\_name | The domain name to configure SES. | `string` | n/a | yes |
-| enable\_incoming\_email | Control whether or not to handle incoming emails | `string` | `true` | no |
-| enable\_verification | Control whether or not to verify SES DNS records. | `string` | `true` | no |
-| from\_addresses | List of email addresses to catch bounces and rejections | `list(string)` | n/a | yes |
+| enable\_incoming\_email | Control whether or not to handle incoming emails. | `bool` | `true` | no |
+| enable\_spf\_record | Control whether or not to set SPF records. | `bool` | `true` | no |
+| enable\_verification | Control whether or not to verify SES DNS records. | `bool` | `true` | no |
+| from\_addresses | List of email addresses to catch bounces and rejections. | `list(string)` | n/a | yes |
 | mail\_from\_domain | Subdomain (of the route53 zone) which is to be used as MAIL FROM address | `string` | n/a | yes |
 | receive\_s3\_bucket | Name of the S3 bucket to store received emails. | `string` | n/a | yes |
 | receive\_s3\_prefix | The key prefix of the S3 bucket to store received emails. | `string` | n/a | yes |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -121,7 +121,7 @@ module "ses_domain" {
 
   receive_s3_bucket = module.ses_bucket.id
   receive_s3_prefix = local.ses_bucket_prefix
-  enable_spf_record = false
+  enable_spf_record = var.enable_spf_record
 
   ses_rule_set = aws_ses_receipt_rule_set.main.rule_set_name
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -96,13 +96,13 @@ resource "aws_route53_record" "temp_domain_ns_records" {
   records = aws_route53_zone.temp_domain.name_servers
 }
 
-# resource "aws_route53_record" "temp_spf" {
-#   zone_id = data.aws_route53_zone.infra_test_truss_coffee.zone_id
-#   name    = var.test_name
-#   type    = "TXT"
-#   ttl     = "600"
-#   records = ["v=spf1 include:_spf.google.com include:servers.mcsv.net ~all"]
-# }
+resource "aws_route53_record" "temp_spf" {
+  zone_id = data.aws_route53_zone.infra_test_truss_coffee.zone_id
+  name    = var.test_name
+  type    = "TXT"
+  ttl     = "600"
+  records = ["v=spf1 include:_spf.google.com include:servers.mcsv.net ~all"]
+}
 
 #
 # SES Domain

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -97,6 +97,7 @@ resource "aws_route53_record" "temp_domain_ns_records" {
 }
 
 resource "aws_route53_record" "temp_spf" {
+  count   = var.enable_spf_record ? 0 : 1
   zone_id = aws_route53_zone.temp_domain.zone_id
   name    = local.temp_domain
   type    = "TXT"

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -97,8 +97,8 @@ resource "aws_route53_record" "temp_domain_ns_records" {
 }
 
 resource "aws_route53_record" "temp_spf" {
-  zone_id = data.aws_route53_zone.infra_test_truss_coffee.zone_id
-  name    = var.test_name
+  zone_id = aws_route53_zone.temp_domain.zone_id
+  name    = local.temp_domain
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:_spf.google.com include:servers.mcsv.net ~all"]

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -96,6 +96,14 @@ resource "aws_route53_record" "temp_domain_ns_records" {
   records = aws_route53_zone.temp_domain.name_servers
 }
 
+# resource "aws_route53_record" "temp_spf" {
+#   zone_id = data.aws_route53_zone.infra_test_truss_coffee.zone_id
+#   name    = var.test_name
+#   type    = "TXT"
+#   ttl     = "600"
+#   records = ["v=spf1 include:_spf.google.com include:servers.mcsv.net ~all"]
+# }
+
 #
 # SES Domain
 #
@@ -113,6 +121,7 @@ module "ses_domain" {
 
   receive_s3_bucket = module.ses_bucket.id
   receive_s3_prefix = local.ses_bucket_prefix
+  enable_spf_record = false
 
   ses_rule_set = aws_ses_receipt_rule_set.main.rule_set_name
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -9,3 +9,7 @@ variable "region" {
 variable "ses_bucket" {
   type = string
 }
+
+variable "enable_spf_record" {
+  type = bool
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/trussworks/terraform-aws-ses-domain
 
 go 1.13
 
-require github.com/gruntwork-io/terratest v0.26.1
+require (
+	github.com/gruntwork-io/terratest v0.26.1
+	github.com/stretchr/testify v1.5.1
+)

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/main.tf
+++ b/main.tf
@@ -61,13 +61,14 @@ resource "aws_ses_domain_mail_from" "main" {
   mail_from_domain = local.stripped_mail_from_domain
 }
 
-# SPF validaton record
+# SPF validation record
 resource "aws_route53_record" "spf_mail_from" {
   zone_id = var.route53_zone_id
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:amazonses.com -all"]
+  count   = var.enable_spf_record ? 1 : 0
 }
 
 resource "aws_route53_record" "spf_domain" {
@@ -76,6 +77,7 @@ resource "aws_route53_record" "spf_domain" {
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:amazonses.com -all"]
+  count   = var.enable_spf_record ? 1 : 0
 }
 
 # Sending MX Record

--- a/main.tf
+++ b/main.tf
@@ -63,21 +63,21 @@ resource "aws_ses_domain_mail_from" "main" {
 
 # SPF validation record
 resource "aws_route53_record" "spf_mail_from" {
+  count   = var.enable_spf_record ? 1 : 0
   zone_id = var.route53_zone_id
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:amazonses.com -all"]
-  count   = var.enable_spf_record ? 1 : 0
 }
 
 resource "aws_route53_record" "spf_domain" {
+  count   = var.enable_spf_record ? 1 : 0
   zone_id = var.route53_zone_id
   name    = var.domain_name
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:amazonses.com -all"]
-  count   = var.enable_spf_record ? 1 : 0
 }
 
 # Sending MX Record

--- a/test/terraform_aws_ses_domain_test.go
+++ b/test/terraform_aws_ses_domain_test.go
@@ -2,10 +2,12 @@ package test
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
@@ -16,6 +18,7 @@ func TestTerraformSESDomain(t *testing.T) {
 
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
 	testName := fmt.Sprintf("ses-domain-%s", strings.ToLower(random.UniqueId()))
+	testDomain := fmt.Sprintf("%s.infra-test.truss.coffee", testName)
 	sesBucketName := fmt.Sprintf("%s-ses", testName)
 	awsRegion := "us-west-2"
 
@@ -37,4 +40,12 @@ func TestTerraformSESDomain(t *testing.T) {
 
 	terraform.InitAndApply(t, terraformOptions)
 
+	logger.Log(t, testDomain)
+
+	txtrecords, _ := net.LookupTXT(testDomain)
+	logger.Log(t, txtrecords)
+
+	for _, txt := range txtrecords {
+		logger.Log(t, txt)
+	}
 }

--- a/test/terraform_aws_ses_domain_test.go
+++ b/test/terraform_aws_ses_domain_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTerraformSESDomain(t *testing.T) {
@@ -40,12 +41,8 @@ func TestTerraformSESDomain(t *testing.T) {
 
 	terraform.InitAndApply(t, terraformOptions)
 
-	logger.Log(t, testDomain)
-
 	txtrecords, _ := net.LookupTXT(testDomain)
-	logger.Log(t, txtrecords)
 
-	for _, txt := range txtrecords {
-		logger.Log(t, txt)
-	}
+	assert.True(t, collections.ListContains(txtrecords, "v=spf1 include:_spf.google.com include:servers.mcsv.net ~all"))
+	assert.False(t, collections.ListContains(txtrecords, "v=spf1 include:amazonses.com -all"))
 }

--- a/test/terraform_aws_ses_domain_test.go
+++ b/test/terraform_aws_ses_domain_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTerraformSESDomain(t *testing.T) {
+func TestTerraformSESDomainWithSPFEnabled(t *testing.T) {
 	t.Parallel()
 
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
@@ -26,9 +25,10 @@ func TestTerraformSESDomain(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":     awsRegion,
-			"test_name":  testName,
-			"ses_bucket": sesBucketName,
+			"region":            awsRegion,
+			"test_name":         testName,
+			"ses_bucket":        sesBucketName,
+			"enable_spf_record": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -43,6 +43,40 @@ func TestTerraformSESDomain(t *testing.T) {
 
 	txtrecords, _ := net.LookupTXT(testDomain)
 
-	assert.True(t, collections.ListContains(txtrecords, "v=spf1 include:_spf.google.com include:servers.mcsv.net ~all"))
-	assert.False(t, collections.ListContains(txtrecords, "v=spf1 include:amazonses.com -all"))
+	assert.NotContains(t, txtrecords, "v=spf1 include:_spf.google.com include:servers.mcsv.net ~all")
+	assert.Contains(t, txtrecords, "v=spf1 include:amazonses.com -all")
+}
+
+func TestTerraformSESDomainWithSPFDisabled(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
+	testName := fmt.Sprintf("ses-domain-%s", strings.ToLower(random.UniqueId()))
+	testDomain := fmt.Sprintf("%s.infra-test.truss.coffee", testName)
+	sesBucketName := fmt.Sprintf("%s-ses", testName)
+	awsRegion := "us-west-2"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"region":            awsRegion,
+			"test_name":         testName,
+			"ses_bucket":        sesBucketName,
+			"enable_spf_record": false,
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	defer aws.EmptyS3Bucket(t, awsRegion, sesBucketName)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	txtrecords, _ := net.LookupTXT(testDomain)
+
+	assert.Contains(t, txtrecords, "v=spf1 include:_spf.google.com include:servers.mcsv.net ~all")
+	assert.NotContains(t, txtrecords, "v=spf1 include:amazonses.com -all")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,12 @@ variable "domain_name" {
 
 variable "enable_verification" {
   description = "Control whether or not to verify SES DNS records."
-  type        = string
+  type        = bool
   default     = true
 }
 
 variable "from_addresses" {
-  description = "List of email addresses to catch bounces and rejections"
+  description = "List of email addresses to catch bounces and rejections."
   type        = list(string)
 }
 
@@ -45,7 +45,13 @@ variable "ses_rule_set" {
 }
 
 variable "enable_incoming_email" {
-  description = "Control whether or not to handle incoming emails"
-  type        = string
+  description = "Control whether or not to handle incoming emails."
+  type        = bool
+  default     = true
+}
+
+variable "enable_spf_record" {
+  description = "Control whether or not to set SPF records."
+  type        = bool
   default     = true
 }


### PR DESCRIPTION
Based off of pr #15 

Changes include
- enabling the spf records within the module via `enable_spf_record`
- updating the docker image
- modifying the test for creating own spf records outside module
- importing `stretchr/testify` for test assertions
- converting type `string` boolean variables to type `bool`