### PR TITLE
Allow setting the DMARC policy and use variable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ data "aws_route53_zone" "SES_domain" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| dmarc\_rua | Email address for capturing DMARC aggregate reports. | `string` | n/a | yes |
+| dmarc\_p | DMARC Policy for organizational domains (none, quarantine, reject). | `string` | `"none"` | no |
+| dmarc\_rua | DMARC Reporting URI of aggregate reports, expects an email address. | `string` | n/a | yes |
 | domain\_name | The domain name to configure SES. | `string` | n/a | yes |
 | enable\_incoming\_email | Control whether or not to handle incoming emails. | `bool` | `true` | no |
 | enable\_spf\_record | Control whether or not to set SPF records. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ resource "aws_route53_record" "txt_dmarc" {
   name    = "_dmarc.${var.domain_name}"
   type    = "TXT"
   ttl     = "600"
-  records = ["v=DMARC1; p=none; rua=mailto:${var.dmarc_rua};"]
+  records = ["v=DMARC1; p=${var.dmarc_p}; rua=mailto:${var.dmarc_rua};"]
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -2,11 +2,6 @@ variable "dmarc_p" {
   description = "DMARC Policy for organizational domains (none, quarantine, reject)."
   type        = string
   default     = "none"
-
-  validation {
-    condition     = var.dmarc_p == "none" || var.dmarc_p == "quarantine" || var.dmarc_p == "reject"
-    error_message = "This module only supports only policy domains none, quarantine, and reject."
-  }
 }
 
 variable "dmarc_rua" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,16 @@
+variable "dmarc_p" {
+  description = "DMARC Policy for organizational domains (none, quarantine, reject)."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = var.dmarc_p == "none" || var.dmarc_p == "quarantine" || var.dmarc_p == "reject"
+    error_message = "This module only supports only policy domains none, quarantine, and reject."
+  }
+}
+
 variable "dmarc_rua" {
-  description = "Email address for capturing DMARC aggregate reports."
+  description = "DMARC Reporting URI of aggregate reports, expects an email address."
   type        = string
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,5 @@
 
 terraform {
   required_version = ">= 0.12"
+  experiments      = [variable_validation]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,4 @@
 
 terraform {
   required_version = ">= 0.12"
-  experiments      = [variable_validation]
 }


### PR DESCRIPTION
I was recently asked to update the policy on my DMARC record and set it to `reject` instead of `none`. 

Edit: I removed validation because of terratest ...

This adds the ability to set it as a variable and uses the new [custom variable validation](https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules) terraform experiment that is now available.