### PR TITLE
Don't require s3 bucket when incoming email disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ data "aws_route53_zone" "SES_domain" {
 | enable\_verification | Control whether or not to verify SES DNS records. | `bool` | `true` | no |
 | from\_addresses | List of email addresses to catch bounces and rejections. | `list(string)` | n/a | yes |
 | mail\_from\_domain | Subdomain (of the route53 zone) which is to be used as MAIL FROM address | `string` | n/a | yes |
-| receive\_s3\_bucket | Name of the S3 bucket to store received emails. | `string` | n/a | yes |
-| receive\_s3\_prefix | The key prefix of the S3 bucket to store received emails. | `string` | n/a | yes |
+| receive\_s3\_bucket | Name of the S3 bucket to store received emails (required if enable\_incoming\_email is true). | `string` | `""` | no |
+| receive\_s3\_prefix | The key prefix of the S3 bucket to store received emails (required if enable\_incoming\_email is true). | `string` | `""` | no |
 | route53\_zone\_id | Route53 host zone ID to enable SES. | `string` | n/a | yes |
 | ses\_rule\_set | Name of the SES rule set to associate rules with. | `string` | n/a | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,8 @@ resource "aws_ses_domain_dkim" "main" {
 }
 
 resource "aws_route53_record" "dkim" {
-  count   = 3
+  count = 3
+
   zone_id = var.route53_zone_id
   name = format(
     "%s._domainkey.%s",
@@ -63,7 +64,8 @@ resource "aws_ses_domain_mail_from" "main" {
 
 # SPF validation record
 resource "aws_route53_record" "spf_mail_from" {
-  count   = var.enable_spf_record ? 1 : 0
+  count = var.enable_spf_record ? 1 : 0
+
   zone_id = var.route53_zone_id
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "TXT"
@@ -72,7 +74,8 @@ resource "aws_route53_record" "spf_mail_from" {
 }
 
 resource "aws_route53_record" "spf_domain" {
-  count   = var.enable_spf_record ? 1 : 0
+  count = var.enable_spf_record ? 1 : 0
+
   zone_id = var.route53_zone_id
   name    = var.domain_name
   type    = "TXT"
@@ -94,7 +97,8 @@ resource "aws_route53_record" "mx_send_mail_from" {
 
 # Receiving MX Record
 resource "aws_route53_record" "mx_receive" {
-  count   = var.enable_incoming_email ? 1 : 0
+  count = var.enable_incoming_email ? 1 : 0
+
   name    = var.domain_name
   zone_id = var.route53_zone_id
   type    = "MX"
@@ -118,8 +122,9 @@ resource "aws_route53_record" "txt_dmarc" {
 #
 
 resource "aws_ses_receipt_rule" "main" {
+  count = var.enable_incoming_email ? 1 : 0
+
   name          = format("%s-s3-rule", local.dash_domain)
-  count         = var.enable_incoming_email ? 1 : 0
   rule_set_name = var.ses_rule_set
   recipients    = var.from_addresses
   enabled       = true

--- a/variables.tf
+++ b/variables.tf
@@ -31,13 +31,15 @@ variable "mail_from_domain" {
 }
 
 variable "receive_s3_bucket" {
-  description = "Name of the S3 bucket to store received emails."
+  description = "Name of the S3 bucket to store received emails (required if enable_incoming_email is true)."
   type        = string
+  default     = ""
 }
 
 variable "receive_s3_prefix" {
-  description = "The key prefix of the S3 bucket to store received emails."
+  description = "The key prefix of the S3 bucket to store received emails (required if enable_incoming_email is true)."
   type        = string
+  default     = ""
 }
 
 variable "route53_zone_id" {


### PR DESCRIPTION
I ran into this while trying to remove the buckets I had for incoming email. Changing this to optional and will retag at v2.0.5.