### PR TITLE
Remove the providers file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,12 @@ data "aws_route53_zone" "SES_domain" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | n/a |
 
 ## Inputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -86,7 +86,7 @@ resource "aws_s3_bucket_public_access_block" "public_access_block" {
 
 module "s3_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 4"
+  version = "~> 8"
 
   s3_bucket_name = "${var.test_name}-logs"
   region         = var.region

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 2.70"
-}


### PR DESCRIPTION
I've removed the `providers.tf` file as I expect terraform modules not to provide them. I reran the tests and I didn't have an error. So I'd love to get this reviewed by someone else to see if we can reproduce the error which was the reason for adding this before and then figure out what is different. My test command was:

```sh
AWS_VAULT_KEYCHAIN_NAME=login aws-vault exec trussworks-ci -- make test
```