### PR TITLE
Fix bug when disabling domain verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ data "aws_route53_zone" "SES_domain" {
 | Name | Description |
 |------|-------------|
 | ses\_identity\_arn | SES identity ARN. |
+| ses\_verification\_token | A code which when added to the domain as a TXT record will signal to SES that the owner of the domain has authorised SES to act on their behalf. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -129,7 +129,7 @@ resource "aws_route53_record" "temp_verification" {
   name    = "_amazonses.${local.temp_domain}"
   type    = "TXT"
   ttl     = "600"
-  records = [var.test_name]
+  records = [module.ses_domain.ses_verification_token]
 }
 
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -123,6 +123,16 @@ resource "aws_route53_record" "temp_spf" {
   records = ["v=spf1 include:_spf.google.com include:servers.mcsv.net ~all"]
 }
 
+resource "aws_route53_record" "temp_verification" {
+  count   = var.enable_verification ? 0 : 1
+  zone_id = aws_route53_zone.temp_domain.zone_id
+  name    = "_amazonses.${local.temp_domain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [var.test_name]
+}
+
+
 #
 # SES Domain
 #
@@ -138,10 +148,12 @@ module "ses_domain" {
 
   dmarc_rua = "email@hurts.com"
 
-  receive_s3_bucket = aws_s3_bucket.temp_bucket.id
-  receive_s3_prefix = local.ses_bucket_prefix
-  enable_spf_record = var.enable_spf_record
-  extra_ses_records = var.extra_ses_records
+  receive_s3_bucket   = aws_s3_bucket.temp_bucket.id
+  receive_s3_prefix   = local.ses_bucket_prefix
+  enable_verification = var.enable_verification
+  enable_spf_record   = var.enable_spf_record
+  extra_ses_records   = var.extra_ses_records
+
 
   ses_rule_set = aws_ses_receipt_rule_set.main.rule_set_name
 }

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -1,0 +1,3 @@
+output "ses_verification_token" {
+  value = module.ses_domain.ses_verification_token
+}

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -6,6 +6,10 @@ variable "ses_bucket" {
   type = string
 }
 
+variable "enable_verification" {
+  type = bool
+}
+
 variable "enable_spf_record" {
   type = bool
 }

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "aws_ses_domain_identity_verification" "main" {
 }
 
 resource "aws_route53_record" "ses_verification" {
+  count   = var.enable_verification ? 1 : 0
   zone_id = var.route53_zone_id
   name    = "_amazonses.${aws_ses_domain_identity.main.id}"
   type    = "TXT"

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "ses_identity_arn" {
   description = "SES identity ARN."
   value       = aws_ses_domain_identity.main.arn
 }
+
+output "ses_verification_token" {
+  description = "A code which when added to the domain as a TXT record will signal to SES that the owner of the domain has authorised SES to act on their behalf."
+  value       = aws_ses_domain_identity.main.verification_token
+}

--- a/test/terraform_aws_ses_domain_test.go
+++ b/test/terraform_aws_ses_domain_test.go
@@ -135,6 +135,7 @@ func TestTerraformSESDomainWithNoVerificationRecords(t *testing.T) {
 
 	terraform.InitAndApply(t, terraformOptions)
 
+	verificationToken := terraform.Output(t, terraformOptions, "ses_verification_token")
 	txtRecords, _ := net.LookupTXT(testDomain)
-	assert.Contains(t, txtRecords, testName)
+	assert.Contains(t, txtRecords, verificationToken)
 }

--- a/test/terraform_aws_ses_domain_test.go
+++ b/test/terraform_aws_ses_domain_test.go
@@ -24,9 +24,10 @@ func TestTerraformSESDomainWithSPFEnabled(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"test_name":         testName,
-			"ses_bucket":        sesBucketName,
-			"enable_spf_record": true,
+			"test_name":           testName,
+			"ses_bucket":          sesBucketName,
+			"enable_spf_record":   true,
+			"enable_verification": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -55,9 +56,10 @@ func TestTerraformSESDomainWithSPFDisabled(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"test_name":         testName,
-			"ses_bucket":        sesBucketName,
-			"enable_spf_record": false,
+			"test_name":           testName,
+			"ses_bucket":          sesBucketName,
+			"enable_spf_record":   false,
+			"enable_verification": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -87,10 +89,11 @@ func TestTerraformSESDomainWithExtraSESRecords(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"test_name":         testName,
-			"ses_bucket":        sesBucketName,
-			"enable_spf_record": true,
-			"extra_ses_records": extraRecords,
+			"test_name":           testName,
+			"ses_bucket":          sesBucketName,
+			"enable_spf_record":   true,
+			"extra_ses_records":   extraRecords,
+			"enable_verification": true,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -104,4 +107,34 @@ func TestTerraformSESDomainWithExtraSESRecords(t *testing.T) {
 	txtrecords, _ := net.LookupTXT(testDomain)
 
 	assert.Contains(t, txtrecords, "stringThing1.infra-test.truss.coffee")
+}
+
+func TestTerraformSESDomainWithNoVerificationRecords(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
+	testName := fmt.Sprintf("ses-domain-%s", strings.ToLower(random.UniqueId()))
+	testDomain := fmt.Sprintf("_amazonses.%s.infra-test.truss.coffee", testName)
+	sesBucketName := fmt.Sprintf("%s-ses", testName)
+	awsRegion := "us-west-2"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"test_name":           testName,
+			"ses_bucket":          sesBucketName,
+			"enable_spf_record":   true,
+			"enable_verification": false,
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	txtRecords, _ := net.LookupTXT(testDomain)
+	assert.Contains(t, txtRecords, testName)
 }


### PR DESCRIPTION
Fixes https://github.com/trussworks/terraform-aws-ses-domain/issues/62. It turns out we still create the ses verification records in Route53 even with `enable_verification = false`. This PR fixes the issue and adds a test to confirm. 