### PR TITLE
Relax version constraints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci: &circleci trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+  circleci: &circleci trussworks/circleci:efb1042e31538677779971798e0912390f699e72
 
 jobs:
   terratest:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.25.0
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.34.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -24,16 +24,14 @@ Creates the following resources:
 
 ### NOTES
 
-* SES is only available in us-east-1, us-west-2, and eu-west-1
+* SES is only available in a [limited number of AWS Regions](https://docs.aws.amazon.com/general/latest/gr/ses.html).
 * SES out of the box locks the service in development mode; please see this documentation on how to make it production ready. Until the service is in production mode you can only send emails to confirmed email accounts denoted in `from_addresses`
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to ~> 3.X. Submit pull-requests to master branch.
+Terraform 0.13 and newer. Pin module version to ~> 3.X. Submit pull-requests to master branch.
 
 Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to terraform012 branch.
-
-Terraform 0.11. Pin module version to ~> 1.0.2. Submit pull-requests to terraform011 branch.
 
 ## Usage
 
@@ -66,14 +64,14 @@ data "aws_route53_zone" "SES_domain" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
-| aws | ~> 3.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trussworks/terraform-aws-ses-domain
 
-go 1.13
+go 1.15
 
 require (
 	github.com/gruntwork-io/terratest v0.31.2

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
Support Terraform 0.13+, AWS provider 3.0+. This will also include deprecating Terraform 0.11 support. Lastly, update pre-commit hooks.

Resolves https://github.com/trussworks/terraform-aws-ses-domain/issues/68