### PR TITLE
Update circleci image to pull in new terraform-docs version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci: &circleci trussworks/circleci:efb1042e31538677779971798e0912390f699e72
+  circleci: &circleci trussworks/circleci:bb3bffc3e3a69473458103e53873f1bcce6ffc5b
 
 jobs:
   terratest:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.34.1
+    rev: v1.37.0
     hooks:
       - id: golangci-lint


### PR DESCRIPTION
Terraform-docs upgraded with some new sections generated in the README. This PR updates the circleci image to use the same version. I've also updated the pre-commit hooks. 