### PR TITLE
feat: makes dmarc_txt record optional. Defaults to true for backwards compt

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ No modules.
 | dmarc\_p | DMARC Policy for organizational domains (none, quarantine, reject). | `string` | `"none"` | no |
 | dmarc\_rua | DMARC Reporting URI of aggregate reports, expects an email address. | `string` | n/a | yes |
 | domain\_name | The domain name to configure SES. | `string` | n/a | yes |
+| enable\_dmarc | Control whether to create DMARC TXT record. | `bool` | `true` | no |
 | enable\_incoming\_email | Control whether or not to handle incoming emails. | `bool` | `true` | no |
 | enable\_spf\_record | Control whether or not to set SPF records. | `bool` | `true` | no |
 | enable\_verification | Control whether or not to verify SES DNS records. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,8 @@ resource "aws_route53_record" "mx_receive" {
 # DMARC TXT Record
 #
 resource "aws_route53_record" "txt_dmarc" {
+  count = var.enable_dmarc ? 1 : 0
+
   zone_id = var.route53_zone_id
   name    = "_dmarc.${var.domain_name}"
   type    = "TXT"

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "enable_verification" {
   default     = true
 }
 
+variable "enable_dmarc" {
+  description = "Control whether to create DMARC TXT record."
+  type        = bool
+  default     = true
+}
+
 variable "from_addresses" {
   description = "List of email addresses to catch bounces and rejections."
   type        = list(string)


### PR DESCRIPTION
Should address #110 